### PR TITLE
Refactor camera config

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -26,6 +26,8 @@
 #include "utils/logging/Logger.h"
 #include "utils/logging/LoggerData.h"
 #include "utils/logging/LoggerEnums.h"
+#include "vision/definitions/CameraConfig.h"
+#include "vision/definitions/CameraConfigMgr.h"
 #include "vision/DragonVision.h"
 #include "utils/logging/DataTrace.h"
 #include "utils/sensors/SensorData.h"
@@ -322,6 +324,11 @@ void Robot::InitializeRobot()
     {
         m_holonomic = new HolonomicDrive();
     }
+
+    //initialize cameras
+    CameraConfigMgr::GetInstance()->InitCameras(static_cast<MechanismConfigMgr::RobotIdentifier>(teamNumber));
+    auto cameraConfig = CameraConfigMgr::GetInstance()->GetCurrentConfig();
+    auto vision = DragonVision::GetDragonVision();
 
     m_robotState = RobotState::GetInstance();
     m_robotState->Init();

--- a/src/main/cpp/auton/drivePrimitives/VisionDrivePrimitive.cpp
+++ b/src/main/cpp/auton/drivePrimitives/VisionDrivePrimitive.cpp
@@ -44,13 +44,11 @@ void VisionDrivePrimitive::Init(PrimitiveParams *params)
 {
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "ArrivedAtInit", true);
 
-    // m_pipelineMode = params->GetPipeline();
     m_timeout = params->GetTime();
 
     m_timer->Reset();
     m_timer->Start();
 
-    Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "m_pipelineMode", m_pipelineMode);
 
     /*m_dragonVision = DragonVision::GetDragonVision();
     if (m_dragonVision != nullptr)

--- a/src/main/cpp/configs/RobotElementNames.h
+++ b/src/main/cpp/configs/RobotElementNames.h
@@ -38,6 +38,8 @@ public:
 	enum CAMERA_USAGE
 	{
 		UNKNOWN_CAMERA = -1,
+		PLACER,
+		POSITION,
 		MAX_CAMERA
 	};
 

--- a/src/main/cpp/vision/DragonCamera.cpp
+++ b/src/main/cpp/vision/DragonCamera.cpp
@@ -24,7 +24,6 @@
 #include <frc/geometry/Pose3d.h>
 
 DragonCamera::DragonCamera(std::string cameraName, /// <I> camera name/type
-                           PIPELINE pipeline,      /// <I> enum for pipeline
                            units::length::inch_t mountingXDistance,
                            units::length::inch_t mountingYDistance,
                            units::length::inch_t mountingZDistance,

--- a/src/main/cpp/vision/DragonCamera.h
+++ b/src/main/cpp/vision/DragonCamera.h
@@ -27,18 +27,9 @@
 class DragonCamera
 {
 public:
-    enum PIPELINE
-    {
-        UNKNOWN = -1,
-        OFF,
-        MACHINE_LEARNING,
-        APRIL_TAG,
-        COLOR_THRESHOLD
-    };
 
     DragonCamera(
         std::string cameraName,                /// <I> camera name/type
-        PIPELINE pipeline,                     /// <I> enum for pipeline
         units::length::inch_t mountingXOffset, /// <I> x offset of cam from robot center (forward relative to robot is positive)
         units::length::inch_t mountingYOffset, /// <I> y offset of cam from robot center (left relative to robot is positive)
         units::length::inch_t mountingZOffset, /// <I> z offset of cam from robot center (up relative to robot is positive)
@@ -99,7 +90,6 @@ public:
     virtual std::optional<VisionData> GetDataToSpecifiedTag(int id) = 0;
 
     // Getters
-    PIPELINE GetPipeline() const { return m_pipeline; }
     units::angle::degree_t GetCameraPitch() const { return m_cameraPose.Rotation().Y(); }
     units::angle::degree_t GetCameraYaw() const { return m_cameraPose.Rotation().Z(); }
     units::angle::degree_t GetCameraRoll() const { return m_cameraPose.Rotation().X(); } // rotates around x-axis
@@ -113,12 +103,6 @@ public:
         return m_robotCenterToCam;
     }
 
-    // Setters
-    void SetPipeline(PIPELINE pipeline)
-    {
-        m_pipeline = pipeline;
-    }
-
     void SetCameraPosition(
         units::length::inch_t mountingXOffset,
         units::length::inch_t mountingYOffset,
@@ -126,12 +110,10 @@ public:
         units::angle::degree_t pitch,
         units::angle::degree_t yaw,
         units::angle::degree_t roll);
-    virtual bool UpdatePipeline() = 0; // children will handle updating the co-processor to current m_pipeline value
 
 protected:
     frc::Pose3d m_cameraPose;
     frc::Transform3d m_robotCenterToCam;
-    PIPELINE m_pipeline;
     std::string m_cameraName;
 
     const units::length::inch_t m_noteVerticalOffset = units::length::inch_t(0.0); // This represents the note being at the same level as center of robot

--- a/src/main/cpp/vision/DragonLimelight.cpp
+++ b/src/main/cpp/vision/DragonLimelight.cpp
@@ -51,7 +51,7 @@
 DragonLimelight::DragonLimelight(
     std::string networkTableName, /// <I> networkTableName
     LIMELIGHT_MODE usage,
-    DragonCamera::PIPELINE initialPipeline, /// <I> enum for pipeline
+    LIMELIGHT_PIPELINE initialPipeline, /// <I> enum for pipeline
     units::length::inch_t mountingXOffset,  /// <I> x offset of cam from robot center (forward relative to robot)
     units::length::inch_t mountingYOffset,  /// <I> y offset of cam from robot center (left relative to robot)
     units::length::inch_t mountingZOffset,  /// <I> z offset of cam from robot center (up relative to robot)
@@ -61,12 +61,11 @@ DragonLimelight::DragonLimelight(
     LED_MODE ledMode,
     CAM_MODE camMode,
     STREAM_MODE streamMode,
-    SNAPSHOT_MODE snapMode) : DragonCamera(networkTableName, initialPipeline, mountingXOffset, mountingYOffset, mountingZOffset, pitch, yaw, roll),
+    SNAPSHOT_MODE snapMode) : DragonCamera(networkTableName, mountingXOffset, mountingYOffset, mountingZOffset, pitch, yaw, roll),
                               SensorData(),
                               m_networktable(nt::NetworkTableInstance::GetDefault().GetTable(std::string(networkTableName))),
                               m_usage(usage)
 {
-    SetPipeline(initialPipeline);
     SetLEDMode(ledMode);
     SetCamMode(camMode);
     SetStreamMode(streamMode);
@@ -417,6 +416,7 @@ void DragonLimelight::SetCamMode(DragonLimelight::CAM_MODE mode)
         nt->PutNumber("camMode", mode);
     }
 }
+
 
 bool DragonLimelight::UpdatePipeline()
 {

--- a/src/main/cpp/vision/DragonLimelight.h
+++ b/src/main/cpp/vision/DragonLimelight.h
@@ -77,6 +77,15 @@ public:
 
     };
 
+    enum LIMELIGHT_PIPELINE
+    {
+        UNKNOWN = -1,
+        OFF,
+        MACHINE_LEARNING_PL,
+        APRIL_TAG,
+        COLOR_THRESHOLD
+    };
+
     ///-----------------------------------------------------------------------------------
     /// Method:         DragonLimelight (constructor)
     /// Description:    Create the object
@@ -85,7 +94,7 @@ public:
     DragonLimelight(
         std::string name, /// <I> - network table name'
         LIMELIGHT_MODE usage,
-        PIPELINE initialPipeline,              /// <I> enum for starting pipeline
+        LIMELIGHT_PIPELINE initialPipeline,    /// <I> enum for starting pipeline
         units::length::inch_t mountingXOffset, /// <I> x offset of cam from robot center (forward relative to robot)
         units::length::inch_t mountingYOffset, /// <I> y offset of cam from robot center (left relative to robot)
         units::length::inch_t mountingZOffset, /// <I> z offset of cam from robot center (up relative to robot)
@@ -170,4 +179,5 @@ protected:
     double m_lastHeartbeat = START_HB;
     frc::Timer *m_healthTimer;
     LIMELIGHT_MODE m_usage;
+    LIMELIGHT_PIPELINE m_pipeline;
 };

--- a/src/main/cpp/vision/DragonVision.cpp
+++ b/src/main/cpp/vision/DragonVision.cpp
@@ -580,7 +580,7 @@ std::optional<VisionPose> DragonVision::GetRobotPositionMegaTag2(units::angle::d
 	return std::nullopt;
 }
 
-bool DragonVision::SetPipeline(DragonCamera::PIPELINE mode, RobotElementNames::CAMERA_USAGE position)
+/*bool DragonVision::SetPipeline(DragonCamera::PIPELINE mode, RobotElementNames::CAMERA_USAGE position)
 {
 	m_dragonCameraMap[position]->SetPipeline(mode);
 	m_dragonCameraMap[position]->UpdatePipeline();
@@ -590,7 +590,7 @@ bool DragonVision::SetPipeline(DragonCamera::PIPELINE mode, RobotElementNames::C
 DragonCamera::PIPELINE DragonVision::GetPipeline(RobotElementNames::CAMERA_USAGE position)
 {
 	return m_dragonCameraMap[position]->GetPipeline();
-}
+}*/
 
 /*****************
  * testAndLogVisionData:  Test and log the vision data

--- a/src/main/cpp/vision/DragonVision.h
+++ b/src/main/cpp/vision/DragonVision.h
@@ -60,12 +60,12 @@ public:
     /// @param mode the pipeline to set the camera to
     /// @param position the physical position of the camera
     /// @return if successful or not (not currently implemented)
-    bool SetPipeline(DragonCamera::PIPELINE mode, RobotElementNames::CAMERA_USAGE position);
+    //bool SetPipeline(DragonCamera::PIPELINE mode, RobotElementNames::CAMERA_USAGE position);
 
     /// @brief gets the pipeline of the camera at the chosen position
     /// @param position the physical position of the camera
     /// @return DragonCamera::PIPELINE - the currently selected pipeline
-    DragonCamera::PIPELINE GetPipeline(RobotElementNames::CAMERA_USAGE position);
+    //DragonCamera::PIPELINE GetPipeline(RobotElementNames::CAMERA_USAGE position);
 
     /// @brief gets the field position of the robot (right blue driverstation origin)
     /// @return std::optional<VisionPose> - the estimated position, timestamp of estimation, and confidence as array of std devs

--- a/src/main/cpp/vision/DragonVisionStructLogger.cpp
+++ b/src/main/cpp/vision/DragonVisionStructLogger.cpp
@@ -76,7 +76,6 @@ void DragonVisionStructLogger::logRotation3d(const std::string &loggerName, cons
 void DragonVisionStructLogger::logDragonCamera(const std::string &loggerName, const DragonCamera &camera)
 {
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, loggerName, std::string("CameraName"), camera.GetCameraName());
-    Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, loggerName, std::string("Pipeline"), std::to_string(camera.GetPipeline()));
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, loggerName, std::string("MountingXOffset"), std::to_string(camera.GetMountingXOffset().to<double>()));
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, loggerName, std::string("MountingYOffset"), std::to_string(camera.GetMountingYOffset().to<double>()));
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, loggerName, std::string("MountingZOffset"), std::to_string(camera.GetMountingZOffset().to<double>()));

--- a/src/main/cpp/vision/definitions/CameraConfig.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfig.cpp
@@ -1,3 +1,4 @@
+
 //====================================================================================================================================================
 // Copyright 2025 Lake Orion Robotics FIRST Team 302
 //
@@ -12,47 +13,22 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 // OR OTHER DEALINGS IN THE SOFTWARE.
 //====================================================================================================================================================
-#pragma once
 
-// C++ Includes
-#include <memory>
+#include "vision/definitions/CameraConfig.h"
 
-// Team302 Includes
-#include "auton/PrimitiveParams.h"
-#include "auton/drivePrimitives/IPrimitive.h"
-#include "chassis/SwerveChassis.h"
-#include "chassis/ChassisOptionEnums.h"
-#include "vision/DragonVision.h"
-
-// FRC,WPI Includes
-#include "frc/controller/HolonomicDriveController.h"
-#include "frc/controller/RamseteController.h"
-#include "frc/Filesystem.h"
-#include "frc/geometry/Pose2d.h"
-#include "frc/trajectory/TrajectoryConfig.h"
-#include "frc/trajectory/TrajectoryUtil.h"
-#include "wpi/SmallString.h"
-#include "frc/Timer.h"
-#include "units/time.h"
-
-class VisionDrivePrimitive : public IPrimitive
+CameraConfig::CameraConfig()
 {
-public:
-    VisionDrivePrimitive();
+}
 
-    virtual ~VisionDrivePrimitive() = default;
+void CameraConfig::BuildCameraConfig()
+{
+    DefineCameras();
+}
 
-    void Init(PrimitiveParams *params) override;
-    void Run() override;
-    bool IsDone() override;
+CameraConfig::~CameraConfig()
+{
+}
 
-private:
-    SwerveChassis *m_chassis;
-    ChassisOptionEnums::HeadingOption m_headingOption;
-    std::string m_ntName;
-
-    frc::Timer *m_timer;
-    units::time::second_t m_timeout;
-
-    DragonVision *m_vision;
-};
+void CameraConfig::DefineCameras()
+{
+}

--- a/src/main/cpp/vision/definitions/CameraConfig.h
+++ b/src/main/cpp/vision/definitions/CameraConfig.h
@@ -1,3 +1,4 @@
+
 //====================================================================================================================================================
 // Copyright 2025 Lake Orion Robotics FIRST Team 302
 //
@@ -12,47 +13,28 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 // OR OTHER DEALINGS IN THE SOFTWARE.
 //====================================================================================================================================================
+
 #pragma once
-
-// C++ Includes
-#include <memory>
-
-// Team302 Includes
-#include "auton/PrimitiveParams.h"
-#include "auton/drivePrimitives/IPrimitive.h"
-#include "chassis/SwerveChassis.h"
-#include "chassis/ChassisOptionEnums.h"
 #include "vision/DragonVision.h"
 
-// FRC,WPI Includes
-#include "frc/controller/HolonomicDriveController.h"
-#include "frc/controller/RamseteController.h"
-#include "frc/Filesystem.h"
-#include "frc/geometry/Pose2d.h"
-#include "frc/trajectory/TrajectoryConfig.h"
-#include "frc/trajectory/TrajectoryUtil.h"
-#include "wpi/SmallString.h"
-#include "frc/Timer.h"
-#include "units/time.h"
-
-class VisionDrivePrimitive : public IPrimitive
+class CameraConfig
 {
 public:
-    VisionDrivePrimitive();
+    enum CAMERA_TYPE
+    {
+        LIMELIGHT4,
+        QUEST
+    };
 
-    virtual ~VisionDrivePrimitive() = default;
+    CameraConfig();
+    ~CameraConfig();
 
-    void Init(PrimitiveParams *params) override;
-    void Run() override;
-    bool IsDone() override;
+    void BuildCameraConfig();
 
-private:
-    SwerveChassis *m_chassis;
-    ChassisOptionEnums::HeadingOption m_headingOption;
-    std::string m_ntName;
+    DragonVision *GetDragonVision() const { return m_vision; }
 
-    frc::Timer *m_timer;
-    units::time::second_t m_timeout;
+protected:
+    virtual void DefineCameras();
 
     DragonVision *m_vision;
 };

--- a/src/main/cpp/vision/definitions/CameraConfigMgr.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfigMgr.cpp
@@ -12,47 +12,48 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 // OR OTHER DEALINGS IN THE SOFTWARE.
 //====================================================================================================================================================
-#pragma once
 
-// C++ Includes
-#include <memory>
+#include <string>
 
-// Team302 Includes
-#include "auton/PrimitiveParams.h"
-#include "auton/drivePrimitives/IPrimitive.h"
-#include "chassis/SwerveChassis.h"
-#include "chassis/ChassisOptionEnums.h"
-#include "vision/DragonVision.h"
+#include "utils/logging/Logger.h"
+#include "vision/definitions/CameraConfigMgr.h"
+#include "vision/definitions/CameraConfig.h"
+#include "vision/definitions/CameraConfig_9997.h"
 
-// FRC,WPI Includes
-#include "frc/controller/HolonomicDriveController.h"
-#include "frc/controller/RamseteController.h"
-#include "frc/Filesystem.h"
-#include "frc/geometry/Pose2d.h"
-#include "frc/trajectory/TrajectoryConfig.h"
-#include "frc/trajectory/TrajectoryUtil.h"
-#include "wpi/SmallString.h"
-#include "frc/Timer.h"
-#include "units/time.h"
+using namespace std;
 
-class VisionDrivePrimitive : public IPrimitive
+CameraConfigMgr *CameraConfigMgr::m_instance = nullptr;
+CameraConfigMgr *CameraConfigMgr::GetInstance()
 {
-public:
-    VisionDrivePrimitive();
+    if (CameraConfigMgr::m_instance == nullptr)
+    {
+        CameraConfigMgr::m_instance = new CameraConfigMgr();
+    }
+    return CameraConfigMgr::m_instance;
+}
 
-    virtual ~VisionDrivePrimitive() = default;
+CameraConfigMgr::CameraConfigMgr() : m_config(nullptr)
+{
+}
 
-    void Init(PrimitiveParams *params) override;
-    void Run() override;
-    bool IsDone() override;
+void CameraConfigMgr::InitCameras(MechanismConfigMgr::RobotIdentifier id)
+{
+    switch (id)
+    {
 
-private:
-    SwerveChassis *m_chassis;
-    ChassisOptionEnums::HeadingOption m_headingOption;
-    std::string m_ntName;
 
-    frc::Timer *m_timer;
-    units::time::second_t m_timeout;
+    case MechanismConfigMgr::RobotIdentifier::CHASSIS_BOT_9997:
+        m_config = new CameraConfig_9997();
+        break;
 
-    DragonVision *m_vision;
-};
+    default:
+        Logger::GetLogger()->LogData(LOGGER_LEVEL::ERROR_ONCE, string("Skipping camera initialization because of unknown robot id "), string(""), id);
+        break;
+    }
+
+    if (m_config != nullptr)
+    {
+        m_config->BuildCameraConfig();
+        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT_ONCE, string("Initialization completed for robot cameras "), string(""), id);
+    }
+}

--- a/src/main/cpp/vision/definitions/CameraConfigMgr.h
+++ b/src/main/cpp/vision/definitions/CameraConfigMgr.h
@@ -12,47 +12,23 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 // OR OTHER DEALINGS IN THE SOFTWARE.
 //====================================================================================================================================================
+
 #pragma once
 
-// C++ Includes
-#include <memory>
+#include "vision/definitions/CameraConfig.h"
+#include "configs/MechanismConfigMgr.h"
 
-// Team302 Includes
-#include "auton/PrimitiveParams.h"
-#include "auton/drivePrimitives/IPrimitive.h"
-#include "chassis/SwerveChassis.h"
-#include "chassis/ChassisOptionEnums.h"
-#include "vision/DragonVision.h"
-
-// FRC,WPI Includes
-#include "frc/controller/HolonomicDriveController.h"
-#include "frc/controller/RamseteController.h"
-#include "frc/Filesystem.h"
-#include "frc/geometry/Pose2d.h"
-#include "frc/trajectory/TrajectoryConfig.h"
-#include "frc/trajectory/TrajectoryUtil.h"
-#include "wpi/SmallString.h"
-#include "frc/Timer.h"
-#include "units/time.h"
-
-class VisionDrivePrimitive : public IPrimitive
+class CameraConfigMgr
 {
 public:
-    VisionDrivePrimitive();
-
-    virtual ~VisionDrivePrimitive() = default;
-
-    void Init(PrimitiveParams *params) override;
-    void Run() override;
-    bool IsDone() override;
+    static CameraConfigMgr *GetInstance();
+    CameraConfig *GetCurrentConfig() const { return m_config; }
+    void InitCameras(MechanismConfigMgr::RobotIdentifier id);
 
 private:
-    SwerveChassis *m_chassis;
-    ChassisOptionEnums::HeadingOption m_headingOption;
-    std::string m_ntName;
+    CameraConfigMgr();
+    ~CameraConfigMgr() = default;
 
-    frc::Timer *m_timer;
-    units::time::second_t m_timeout;
-
-    DragonVision *m_vision;
+    static CameraConfigMgr *m_instance;
+    CameraConfig *m_config;
 };

--- a/src/main/cpp/vision/definitions/CameraConfig_9997.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfig_9997.cpp
@@ -1,0 +1,42 @@
+//====================================================================================================================================================
+// Copyright 2025 Lake Orion Robotics FIRST Team 302
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+// OR OTHER DEALINGS IN THE SOFTWARE.
+//====================================================================================================================================================
+
+#include <string>
+
+#include "vision/definitions/CameraConfig_9997.h"
+#include "vision/DragonVision.h"
+#include "vision/DragonLimelight.h"
+#include "utils/logging/Logger.h"
+
+void CameraConfig_9997::DefineCameras()
+{
+
+    DragonLimelight *placer = new DragonLimelight(std::string("limelight-placer"), //networkTableName
+                                                  DragonLimelight::LIMELIGHT_MODE::MACHINE_LEARNING,     // PIPELINE initialPipeline, 
+                                                  DragonLimelight::LIMELIGHT_PIPELINE::MACHINE_LEARNING_PL,             /// <I> enum for starting pipeline
+                                                  units::length::inch_t(0),                     // units::length::inch_t mountingXOffset, /// <I> x offset of cam from robot center (forward relative to robot)
+                                                  units::length::inch_t(0),                     // units::length::inch_t mountingYOffset, /// <I> y offset of cam from robot center (left relative to robot)
+                                                  units::length::inch_t(0),                     // units::length::inch_t mountingZOffset, /// <I> z offset of cam from robot center (up relative to robot)
+                                                  units::angle::degree_t(0),                    // units::angle::degree_t pitch,          /// <I> - Pitch of camera
+                                                  units::angle::degree_t(0),                    // units::angle::degree_t yaw,            /// <I> - Yaw of camera
+                                                  units::angle::degree_t(0),                    // units::angle::degree_t roll,           /// <I> - Roll of camera
+                                                  DragonLimelight::LED_MODE::LED_OFF,           // LED_MODE ledMode,
+                                                  DragonLimelight::CAM_MODE::CAM_VISION,        // CAM_MODE camMode,
+                                                  DragonLimelight::STREAM_MODE::STREAM_DEFAULT, // STREAM_MODE streamMode,
+                                                  DragonLimelight::SNAPSHOT_MODE::SNAP_OFF     // SNAPSHOT_MODE snapMode
+                                                  );                                         // additional parameter
+    DragonVision::GetDragonVision()->AddCamera(placer, RobotElementNames::CAMERA_USAGE::PLACER);
+
+}

--- a/src/main/cpp/vision/definitions/CameraConfig_9997.h
+++ b/src/main/cpp/vision/definitions/CameraConfig_9997.h
@@ -12,47 +12,21 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 // OR OTHER DEALINGS IN THE SOFTWARE.
 //====================================================================================================================================================
+
 #pragma once
+#include "vision/definitions/CameraConfig.h"
 
-// C++ Includes
-#include <memory>
+#include "units/length.h"
 
-// Team302 Includes
-#include "auton/PrimitiveParams.h"
-#include "auton/drivePrimitives/IPrimitive.h"
-#include "chassis/SwerveChassis.h"
-#include "chassis/ChassisOptionEnums.h"
-#include "vision/DragonVision.h"
-
-// FRC,WPI Includes
-#include "frc/controller/HolonomicDriveController.h"
-#include "frc/controller/RamseteController.h"
-#include "frc/Filesystem.h"
-#include "frc/geometry/Pose2d.h"
-#include "frc/trajectory/TrajectoryConfig.h"
-#include "frc/trajectory/TrajectoryUtil.h"
-#include "wpi/SmallString.h"
-#include "frc/Timer.h"
-#include "units/time.h"
-
-class VisionDrivePrimitive : public IPrimitive
+class CameraConfig_9997 : public CameraConfig
 {
 public:
-    VisionDrivePrimitive();
+    CameraConfig_9997() = default;
+    ~CameraConfig_9997() = default;
 
-    virtual ~VisionDrivePrimitive() = default;
-
-    void Init(PrimitiveParams *params) override;
-    void Run() override;
-    bool IsDone() override;
+protected:
+    void DefineCameras() override;
 
 private:
-    SwerveChassis *m_chassis;
-    ChassisOptionEnums::HeadingOption m_headingOption;
-    std::string m_ntName;
 
-    frc::Timer *m_timer;
-    units::time::second_t m_timeout;
-
-    DragonVision *m_vision;
 };


### PR DESCRIPTION
Have camera config use a similar config to chassis and create camera config for 9997

- removed pipeline definition from DragonCamera as it's a limelight specific thing
- created camera config and camera config mgr
- added initial camera config for 9997