### PR TITLE
Clean Up Pigeon Request/Investigating Drive Issues

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -230,13 +230,10 @@ void Robot::DisabledPeriodic()
             if (megaTag2Position.has_value())
             {
                 chassis->SetYaw(initialRot);
-                chassis->SetStoredHeading(initialRot);
                 chassis->ResetPose(megaTag2Position.value().estimatedPose.ToPose2d());
             }
             else if (hasVisionPose)
             {
-                chassis->SetYaw(initialRot);
-                chassis->SetStoredHeading(initialRot);
                 chassis->ResetPose(visionPosition.value().estimatedPose.ToPose2d());
             }
         }

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -227,13 +227,16 @@ void Robot::DisabledPeriodic()
                                                                      units::angle::degree_t(0.0),
                                                                      units::angular_velocity::degrees_per_second_t(0.0));
 
-            if (megaTag2Position.has_value())
+            if (megaTag2Position.has_value()) // may want to use reset Position instead of reset pose here?
             {
                 chassis->SetYaw(initialRot);
+                chassis->SetStoredHeading(initialRot);
                 chassis->ResetPose(megaTag2Position.value().estimatedPose.ToPose2d());
             }
             else if (hasVisionPose)
             {
+                chassis->SetYaw(initialRot);
+                chassis->SetStoredHeading(initialRot);
                 chassis->ResetPose(visionPosition.value().estimatedPose.ToPose2d());
             }
         }

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -229,14 +229,10 @@ void Robot::DisabledPeriodic()
 
             if (megaTag2Position.has_value()) // may want to use reset Position instead of reset pose here?
             {
-                chassis->SetYaw(initialRot);
-                chassis->SetStoredHeading(initialRot);
                 chassis->ResetPose(megaTag2Position.value().estimatedPose.ToPose2d());
             }
             else if (hasVisionPose)
             {
-                chassis->SetYaw(initialRot);
-                chassis->SetStoredHeading(initialRot);
                 chassis->ResetPose(visionPosition.value().estimatedPose.ToPose2d());
             }
         }

--- a/src/main/cpp/auton/drivePrimitives/ResetPositionPathPlanner.cpp
+++ b/src/main/cpp/auton/drivePrimitives/ResetPositionPathPlanner.cpp
@@ -62,8 +62,8 @@ void ResetPositionPathPlanner::Init(PrimitiveParams *param)
 
                 // Check to see if current pose is within 2 meters (distanceThreshold) of the centerline (centerline), if it isn't, reset pose with pathplanner/choreo
                 auto actualPose = chassis->GetPose();
-                const units::length::meter_t poseDiff = actualPose.X() - m_centerline;
-                bool poseNeedsUpdating = poseDiff > m_distanceThreshold || poseDiff < m_distanceThreshold * -1;
+                const units::length::meter_t poseDiff = units::math::abs(actualPose.X() - m_centerline);
+                bool poseNeedsUpdating = poseDiff > m_distanceThreshold;
 
                 if (poseNeedsUpdating)
                 {

--- a/src/main/cpp/chassis/SwerveChassis.cpp
+++ b/src/main/cpp/chassis/SwerveChassis.cpp
@@ -178,6 +178,7 @@ void SwerveChassis::Drive(ChassisMovement &moveInfo)
     else if (abs(GetRotationRateDegreesPerSecond()) < 5.0) // degrees per second
     {
         m_rotatingLatch = false;
+        SetStoredHeading(GetYaw());
     }
 
     m_currentOrientationState = GetHeadingState(moveInfo);

--- a/src/main/cpp/chassis/SwerveChassis.cpp
+++ b/src/main/cpp/chassis/SwerveChassis.cpp
@@ -166,6 +166,8 @@ void SwerveChassis::ZeroAlignSwerveModules()
 /// @brief Drive the chassis
 void SwerveChassis::Drive(ChassisMovement &moveInfo)
 {
+    UpdateOdometry();
+
     m_drive = moveInfo.chassisSpeeds.vx;
     m_steer = moveInfo.chassisSpeeds.vy;
     m_rotate = moveInfo.chassisSpeeds.omega;
@@ -208,7 +210,6 @@ void SwerveChassis::Drive(ChassisMovement &moveInfo)
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_networkTableName, string("Heading Option"), moveInfo.headingOption);
 
     // m_rotate = moveInfo.chassisSpeeds.omega TO DO this is in place for Data Logging, need to create dataLog method where we pass moveInfo to it and it handels the data logging variables
-    UpdateOdometry();
 }
 
 //==================================================================================

--- a/src/main/cpp/chassis/SwerveChassis.cpp
+++ b/src/main/cpp/chassis/SwerveChassis.cpp
@@ -178,11 +178,6 @@ void SwerveChassis::Drive(ChassisMovement &moveInfo)
         m_rotatingLatch = false;
     }
 
-    if (m_rotatingLatch)
-    {
-        SetStoredHeading(GetYaw());
-    }
-
     m_currentOrientationState = GetHeadingState(moveInfo);
     if (m_currentOrientationState != nullptr)
     {
@@ -212,7 +207,7 @@ void SwerveChassis::Drive(ChassisMovement &moveInfo)
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_networkTableName, string("Drive Option"), moveInfo.driveOption);
     Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_networkTableName, string("Heading Option"), moveInfo.headingOption);
 
-    m_rotate = moveInfo.chassisSpeeds.omega;
+    // m_rotate = moveInfo.chassisSpeeds.omega TO DO this is in place for Data Logging, need to create dataLog method where we pass moveInfo to it and it handels the data logging variables
     UpdateOdometry();
 }
 
@@ -293,6 +288,12 @@ Pose2d SwerveChassis::GetPose() const
 //==================================================================================
 units::angle::degree_t SwerveChassis::GetYaw() const
 {
+    return m_swervePoseEstimator->GetPose().Rotation().Degrees();
+}
+
+//==================================================================================
+units::angle::degree_t SwerveChassis::GetRawYaw() const
+{
     return m_pigeon->GetYaw().Refresh().GetValue();
 }
 
@@ -359,7 +360,6 @@ void SwerveChassis::LogSwerveEncoderData(SwerveChassis::SWERVE_MODULES swerveMod
 void SwerveChassis::ResetPose(const Pose2d &pose)
 {
     ZeroAlignSwerveModules();
-    // Rotation2d rot2d{pose.Rotation().Degrees()};
     SetStoredHeading(pose.Rotation().Degrees());
 
     if (m_swervePoseEstimator != nullptr)

--- a/src/main/cpp/chassis/SwerveChassis.h
+++ b/src/main/cpp/chassis/SwerveChassis.h
@@ -109,6 +109,8 @@ public:
     SwerveModule *GetBackRight() const { return m_backRight; }
     frc::Pose2d GetPose() const;
     units::angle::degree_t GetYaw() const override;
+    units::angle::degree_t GetRawYaw() const;
+
     units::angle::degree_t GetPitch() const;
     units::angle::degree_t GetRoll() const;
 

--- a/src/main/cpp/chassis/SwerveChassis.h
+++ b/src/main/cpp/chassis/SwerveChassis.h
@@ -129,7 +129,7 @@ public:
     ISwerveDriveState *GetSpecifiedDriveState(ChassisOptionEnums::DriveStateType driveOption);
 
     bool IsRotating() const { return m_rotatingLatch; }
-    double GetRotationRateDegreesPerSecond() const { return m_pigeon != nullptr ? m_pigeon->GetAngularVelocityZWorld(true).GetValueAsDouble() : 0.0; }
+    double GetRotationRateDegreesPerSecond() const { return m_pigeon != nullptr ? m_pigeon->GetAngularVelocityZWorld(false).GetValueAsDouble() : 0.0; } // check with true and false, might help with CAN bus load and pigeon is running faster than 20ms that we don't need a refreshed signal most likley
     void LogInformation() override;
     void DataLog() override;
 

--- a/src/main/cpp/chassis/pose/DragonSwervePoseEstimator.cpp
+++ b/src/main/cpp/chassis/pose/DragonSwervePoseEstimator.cpp
@@ -66,7 +66,7 @@ void DragonSwervePoseEstimator::Update()
         {
             SetServeModules(chassis);
         }
-        frc::Rotation2d rot2d{chassis->GetYaw()};
+        frc::Rotation2d rot2d{chassis->GetRawYaw()};
 
         m_poseEstimator.Update(rot2d, wpi::array<frc::SwerveModulePosition, 4>{m_frontLeft->GetPosition(),
                                                                                m_frontRight->GetPosition(),

--- a/src/main/cpp/chassis/states/MaintainHeading.cpp
+++ b/src/main/cpp/chassis/states/MaintainHeading.cpp
@@ -44,16 +44,8 @@ void MaintainHeading::UpdateChassisSpeeds(ChassisMovement &chassisMovement)
     auto chassis = config != nullptr ? config->GetSwerveChassis() : nullptr;
     if (chassis != nullptr)
     {
-        bool wasRotating = false;
-
-        bool isRotating = chassis->IsRotating();
-
-        if (wasRotating && !isRotating) // Gets the transistion from rotating to not rotating
-        {
-            chassis->SetStoredHeading(chassis->GetYaw()); // Or currentAngle.Degrees() if you prefer
-            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("Stored Heading"), chassis->GetStoredHeading().value());
-        }
-        else if (!isRotating)
+        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("Stored Heading"), chassis->GetStoredHeading().value());
+        if (!chassis->IsRotating())
         {
             auto correction = units::angular_velocity::degrees_per_second_t(0.0);
 
@@ -71,7 +63,5 @@ void MaintainHeading::UpdateChassisSpeeds(ChassisMovement &chassisMovement)
             Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("correction"), radianCorrection);
             Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("omega"), chassisMovement.chassisSpeeds.omega.value());
         }
-
-        wasRotating = isRotating; // Update the previous state for the next iteration
     }
 }

--- a/src/main/cpp/chassis/states/MaintainHeading.cpp
+++ b/src/main/cpp/chassis/states/MaintainHeading.cpp
@@ -44,20 +44,34 @@ void MaintainHeading::UpdateChassisSpeeds(ChassisMovement &chassisMovement)
     auto chassis = config != nullptr ? config->GetSwerveChassis() : nullptr;
     if (chassis != nullptr)
     {
-        auto correction = units::angular_velocity::degrees_per_second_t(0.0);
+        bool wasRotating = false;
 
-        auto currentAngle = units::angle::radian_t(AngleUtils::GetEquivAngle(chassis->GetPose().Rotation().Degrees()));
-        auto targetAngle = units::angle::radian_t(AngleUtils::GetEquivAngle(chassis->GetStoredHeading()));
+        bool isRotating = chassis->IsRotating();
 
-        auto radianCorrection = m_controller.Calculate(currentAngle.value(), targetAngle.value());
+        if (wasRotating && !isRotating) // Gets the transistion from rotating to not rotating
+        {
+            chassis->SetStoredHeading(chassis->GetYaw()); // Or currentAngle.Degrees() if you prefer
+            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("Stored Heading"), chassis->GetStoredHeading().value());
+        }
+        else if (!isRotating)
+        {
+            auto correction = units::angular_velocity::degrees_per_second_t(0.0);
 
-        correction = abs(radianCorrection) > m_correctionThreshold ? units::angular_velocity::radians_per_second_t(radianCorrection) : units::angular_velocity::radians_per_second_t(0.0);
-        chassisMovement.chassisSpeeds.omega += correction;
+            auto currentAngle = units::angle::radian_t(AngleUtils::GetEquivAngle(chassis->GetPose().Rotation().Degrees()));
+            auto targetAngle = units::angle::radian_t(AngleUtils::GetEquivAngle(chassis->GetStoredHeading()));
 
-        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("currentAngle"), units::angle::degree_t(currentAngle).value());
-        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("targetAngle"), units::angle::degree_t(targetAngle).value());
-        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("Error"), units::angle::degree_t(targetAngle - currentAngle).value());
-        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("correction"), radianCorrection);
-        Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("omega"), chassisMovement.chassisSpeeds.omega.value());
+            auto radianCorrection = m_controller.Calculate(currentAngle.value(), targetAngle.value());
+
+            correction = abs(radianCorrection) > m_correctionThreshold ? units::angular_velocity::radians_per_second_t(radianCorrection) : units::angular_velocity::radians_per_second_t(0.0);
+            chassisMovement.chassisSpeeds.omega += correction;
+
+            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("currentAngle"), units::angle::degree_t(currentAngle).value());
+            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("targetAngle"), units::angle::degree_t(targetAngle).value());
+            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("Error"), units::angle::degree_t(targetAngle - currentAngle).value());
+            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("correction"), radianCorrection);
+            Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("maintain"), string("omega"), chassisMovement.chassisSpeeds.omega.value());
+        }
+
+        wasRotating = isRotating; // Update the previous state for the next iteration
     }
 }

--- a/src/main/cpp/chassis/states/MaintainHeading.h
+++ b/src/main/cpp/chassis/states/MaintainHeading.h
@@ -33,7 +33,6 @@ public:
     void UpdateChassisSpeeds(ChassisMovement &chassisMovement) override;
 
 private:
-    bool m_prevTranslatinOrStrafing = false;
     double m_correctionThreshold = 0.1;
     frc::PIDController m_controller{4.0, 0.5, 0.0};
 };

--- a/src/main/cpp/chassis/states/TrajectoryDrivePathPlanner.cpp
+++ b/src/main/cpp/chassis/states/TrajectoryDrivePathPlanner.cpp
@@ -164,7 +164,7 @@ bool TrajectoryDrivePathPlanner::IsDone()
             Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, "TrajectoryDrive", "target pose Y", m_finalState.pose.Y().value());
             Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, "TrajectoryDrive", "target pose Rotation", m_finalState.pose.Rotation().Degrees().value());
 
-            isDone = IsSamePose(currentPose, m_finalState.pose, m_chassis->GetChassisSpeeds(), 10.0, 3.0, 1.5);
+            isDone = IsSamePose(currentPose, m_finalState.pose, m_chassis->GetChassisSpeeds(), 10.0, 3.0, 1.5); // TO DO verify these values
         }
     }
     else

--- a/src/main/deploy/auton/RedLeftILCoralL4.xml
+++ b/src/main/deploy/auton/RedLeftILCoralL4.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE auton SYSTEM "auton.dtd">
+<auton>
+
+<primitive id= "RESET_POSITION_PATH_PLANNER"
+choreoname = "BlueLeftOutside_J"/>
+
+<primitive id = "DRIVE_PATH_PLANNER"
+choreoname = "BlueLeftOutside_J"
+time="2.0">
+<zone filename="RedReefPlacerZones.xml"/>
+</primitive>
+
+<primitive id = "DRIVE_STOP_MECH"
+taleOption="STATE_SCORE_CORAL"
+time="5.0"/>
+
+<primitive id = "DRIVE_PATH_PLANNER"
+choreoname = "BlueLeftCSA_J2"
+taleOption="STATE_HUMAN_PLAYER_LOAD"
+time = "1.5"/>
+
+<primitive id = "DRIVE_STOP_MECH"
+time="10.0"/>
+
+
+<primitive id = "DRIVE_PATH_PLANNER"
+choreoname = "BlueLeftCSA_K1"
+time = "2.0">
+<zone filename="RedReefPlacerZones.xml"/>
+</primitive>
+
+<primitive id = "DRIVE_STOP_MECH"
+taleOption="STATE_SCORE_CORAL"
+time="5.0"/>
+
+<primitive id = "DRIVE_PATH_PLANNER"
+choreoname = "BlueLeftCSA_K2"
+taleOption="STATE_HUMAN_PLAYER_LOAD"
+time = "1.4"/>
+
+<primitive id = "DRIVE_STOP_MECH"
+time="5.0"/>
+
+<primitive id = "DRIVE_PATH_PLANNER"
+choreoname = "BlueLeftCSA_L1"
+filename="RedReefPlacerZones.xml"
+time = "1.3">
+<zone filename="RedReefPlacerZones.xml"/>
+</primitive>
+
+<primitive id = "DRIVE_STOP_MECH"
+taleOption="STATE_SCORE_CORAL"
+time="5.0"/>
+
+<primitive id ="DO_NOTHING"
+time="1.0"/> 
+
+</auton>


### PR DESCRIPTION
Hey Joe,

Please take a look at this pull request and let me know if you have any questions or disagree with the changes. I made it so we only call the pigeon directly once and the rest of the time get the position from the pose estimator  (even moved the update odometery to the beginning)

Lastly in DragonSwervePoseEstimator we have a ResetPosition() method that isn't being used anywhere. I think this is okay, but wanted to discuss with you when we should use this method vs using the RestPose Method. This could be some of the confusion with driving the write direction after auton 