### PR TITLE
Allow constant time for datalogging

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -27,12 +27,12 @@
 #include "utils/logging/debug/Logger.h"
 #include "utils/logging/signals/DragonDataLoggerMgr.h"
 #include "utils/PeriodicLooper.h"
+#include "utils/RoboRio.h"
 #include "utils/sensors/SensorData.h"
 #include "utils/sensors/SensorDataMgr.h"
 #include "vision/definitions/CameraConfig.h"
 #include "vision/definitions/CameraConfigMgr.h"
 #include "vision/DragonVision.h"
-#include "utils/RoboRio.h"
 
 using std::string;
 
@@ -67,10 +67,10 @@ void Robot::RobotPeriodic()
         Logger::GetLogger()->PeriodicLog();
     }
 
-    // if (m_datalogger != nullptr && !frc::DriverStation::IsDisabled())
-    // {
-    //     m_datalogger->PeriodicDataLog();
-    // }
+    if (m_datalogger != nullptr && !frc::DriverStation::IsDisabled())
+    {
+        m_datalogger->PeriodicDataLog();
+    }
 
     if (m_robotState != nullptr)
     {

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -69,7 +69,7 @@ void Robot::RobotPeriodic()
 
     if (m_datalogger != nullptr && !frc::DriverStation::IsDisabled())
     {
-        m_datalogger->PeriodicDataLog();
+        // m_datalogger->PeriodicDataLog();
     }
 
     if (m_robotState != nullptr)

--- a/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.cpp
+++ b/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.cpp
@@ -51,6 +51,7 @@ DragonDataLoggerMgr::DragonDataLoggerMgr() : m_items() //, m_doubleDatalogSignal
     SignalLogger::SetPath(GetLoggingDir().c_str());
     SignalLogger::EnableAutoLogging(true);
     SignalLogger::Start();
+    m_timer.Start();
 }
 
 DragonDataLoggerMgr::~DragonDataLoggerMgr()
@@ -102,11 +103,7 @@ void DragonDataLoggerMgr::PeriodicDataLog()
     {
         auto item = m_items[m_lastIndex];
         item->DataLog(timestamp);
-        m_lastIndex++;
-        if (m_lastIndex >= m_items.size())
-        {
-            m_lastIndex = 0;
-        }
+        m_lastIndex += ((m_lastIndex >= (m_items.size() - 1)) ? -m_lastIndex : 1);
     }
     // for (auto item : m_items)
     //{

--- a/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.cpp
+++ b/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.cpp
@@ -93,14 +93,25 @@ void DragonDataLoggerMgr::RegisterItem(DragonDataLogger *item)
     m_items.emplace_back(item);
 }
 
-void DragonDataLoggerMgr::PeriodicDataLog() const
+void DragonDataLoggerMgr::PeriodicDataLog()
 {
     uint64_t timestamp = frc::RobotController::GetFPGATime();
 
-    for (auto item : m_items)
+    m_timer.Reset();
+    while (m_timer.Get() < m_period)
     {
+        auto item = m_items[m_lastIndex];
         item->DataLog(timestamp);
+        m_lastIndex++;
+        if (m_lastIndex >= m_items.size())
+        {
+            m_lastIndex = 0;
+        }
     }
-    // wpi::log::DataLog &log = frc::DataLogManager::GetLog();
-    // log.Flush();
+    // for (auto item : m_items)
+    //{
+    //     item->DataLog(timestamp);
+    // }
+    //  wpi::log::DataLog &log = frc::DataLogManager::GetLog();
+    //  log.Flush();
 }

--- a/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.h
+++ b/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.h
@@ -18,6 +18,7 @@
 #include <array>
 #include <vector>
 
+#include "frc/Timer.h"
 #include "utils/logging/signals/DragonDataLogger.h"
 
 class DragonDataLoggerMgr
@@ -25,7 +26,7 @@ class DragonDataLoggerMgr
 public:
     static DragonDataLoggerMgr *GetInstance();
     void RegisterItem(DragonDataLogger *item);
-    void PeriodicDataLog() const;
+    void PeriodicDataLog();
 
 private:
     DragonDataLoggerMgr();
@@ -34,6 +35,10 @@ private:
     std::string GetLoggingDir();
 
     std::vector<DragonDataLogger *> m_items;
+    frc::Timer m_timer;
+    int m_lastIndex = -1;
+
+    const units::time::second_t m_period{0.0025};
 
     static DragonDataLoggerMgr *m_instance;
 };

--- a/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.h
+++ b/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.h
@@ -36,7 +36,7 @@ private:
 
     std::vector<DragonDataLogger *> m_items;
     frc::Timer m_timer;
-    int m_lastIndex = -1;
+    unsigned int m_lastIndex = 0;
 
     const units::time::second_t m_period{0.0025};
 

--- a/src/main/cpp/vision/definitions/CameraConfig_302.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfig_302.cpp
@@ -55,7 +55,7 @@ void CameraConfig_302::BuildCameraConfig()
                                                 DRAGON_LIMELIGHT_CAM_MODE::CAM_VISION      // CAM_MODE camMode,
 
     ); // additional parameter
-    DragonVision::GetDragonVision()->AddLimelight(back, DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
+    // DragonVision::GetDragonVision()->AddLimelight(back, DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
 
     new DragonQuest(units::length::meter_t(-.319),  // <I> x offset of Quest from robot center (forward relative to robot)
                     units::length::meter_t(0.0384), // <I> y offset of Quest from robot center (left relative to robot)


### PR DESCRIPTION
Loop through the DragonDataLogger items and once a timer is hits a defined period, end the loop.   Start the next loop with the next item in the vector.