### PR TITLE
Fixing dragon quest

### DIFF
--- a/src/main/cpp/chassis/definitions/ChassisConfigMgr.cpp
+++ b/src/main/cpp/chassis/definitions/ChassisConfigMgr.cpp
@@ -61,7 +61,7 @@ void ChassisConfigMgr::InitChassis(RobotIdentifier id)
 		break;
 
 	case RobotIdentifier::SIM_BOT_0:
-		m_config = new ChassisConfigChassis_9999();
+		m_config = new ChassisConfigCompBot_302();
 		break;
 
 	default:

--- a/src/main/cpp/chassis/definitions/chassis302/TunerConstants302.h
+++ b/src/main/cpp/chassis/definitions/chassis302/TunerConstants302.h
@@ -122,9 +122,8 @@ public:
     static constexpr bool kFrontLeftSteerMotorInverted = true;
     static constexpr bool kFrontLeftEncoderInverted = false;
 
-    static constexpr units::inch_t kFrontLeftXPos = 11.25_in;
-    static constexpr units::inch_t kFrontLeftYPos = 12.25_in;
-
+    static constexpr units::inch_t kFrontLeftXPos = 11.375_in;
+    static constexpr units::inch_t kFrontLeftYPos = 12.375_in;
     // Front Right
     static constexpr int kFrontRightDriveMotorId = 20;
     static constexpr int kFrontRightSteerMotorId = 22;
@@ -133,8 +132,8 @@ public:
     static constexpr bool kFrontRightSteerMotorInverted = true;
     static constexpr bool kFrontRightEncoderInverted = false;
 
-    static constexpr units::inch_t kFrontRightXPos = 11.25_in;
-    static constexpr units::inch_t kFrontRightYPos = -12.25_in;
+    static constexpr units::inch_t kFrontRightXPos = 11.375_in;
+    static constexpr units::inch_t kFrontRightYPos = -12.375_in;
 
     // Back Left
     static constexpr int kBackLeftDriveMotorId = 0;
@@ -144,8 +143,8 @@ public:
     static constexpr bool kBackLeftSteerMotorInverted = true;
     static constexpr bool kBackLeftEncoderInverted = false;
 
-    static constexpr units::inch_t kBackLeftXPos = -11.25_in;
-    static constexpr units::inch_t kBackLeftYPos = 12.25_in;
+    static constexpr units::inch_t kBackLeftXPos = -11.375_in;
+    static constexpr units::inch_t kBackLeftYPos = 12.375_in;
 
     // Back Right
     static constexpr int kBackRightDriveMotorId = 1;
@@ -155,6 +154,6 @@ public:
     static constexpr bool kBackRightSteerMotorInverted = true;
     static constexpr bool kBackRightEncoderInverted = false;
 
-    static constexpr units::inch_t kBackRightXPos = -11.25_in;
-    static constexpr units::inch_t kBackRightYPos = -12.25_in;
+    static constexpr units::inch_t kBackRightXPos = -11.375_in;
+    static constexpr units::inch_t kBackRightYPos = -12.375_in;
 };

--- a/src/main/cpp/vision/DragonQuest.cpp
+++ b/src/main/cpp/vision/DragonQuest.cpp
@@ -39,6 +39,12 @@ DragonQuest::DragonQuest(
 
     m_rotationTopic = m_networktable.get()->GetDoubleArrayTopic("euler angles");
     m_initialPosePublisher = m_networktable.get()->GetDoubleArrayTopic("resetpose").Publish();
+
+    // This transform is from the robot center to the Quest sensor
+    m_robotToQuestTransform = frc::Transform2d{
+        frc::Translation2d(m_mountingXOffset, m_mountingYOffset),
+        frc::Rotation2d(m_mountingYaw)};
+    m_questTransform = m_robotToQuestTransform.Inverse(); // Invert to get Quest to robot transform
 }
 
 frc::Pose2d DragonQuest::GetEstimatedPose()
@@ -57,6 +63,7 @@ frc::Pose2d DragonQuest::GetEstimatedPose()
 
     frc::Pose2d questPose{x, y, yaw};
     frc::Pose2d robotPose = questPose + m_questTransform;
+
     return robotPose;
 }
 
@@ -93,6 +100,7 @@ void DragonQuest::DataLog(uint64_t timestamp)
     Log2DPoseData(timestamp, DragonDataLogger::PoseSingals::CURRENT_CHASSIS_QUEST_POSE2D, GetEstimatedPose());
     auto field = DragonField::GetInstance();
     field->AddPose("Quest", GetEstimatedPose());
+    field->AddPose("Quest Initial Pose", m_initialQuestPose);
 }
 
 void DragonQuest::RefreshNT()
@@ -108,13 +116,10 @@ void DragonQuest::SetRobotPose(const frc::Pose2d &pose)
 {
     if (!m_hasreset)
     {
-        auto x = (pose.X() + m_mountingXOffset);
-        auto y = (pose.Y() + m_mountingYOffset);
-        auto rot = (pose.Rotation().Degrees() + m_mountingYaw);
+        frc::Pose2d questPose = pose + m_robotToQuestTransform;
+        m_initialQuestPose = questPose; // Save the initial pose for logging purposes
 
-        m_initialPosePublisher.Set(std::array<double, 3>{x.value(), y.value(), rot.value()});
-
-        m_questTransform = pose - frc::Pose2d{x, y, frc::Rotation2d(rot)};
+        m_initialPosePublisher.Set(std::array<double, 3>{questPose.X().value(), questPose.Y().value(), questPose.Rotation().Degrees().value()});
 
         if (m_questMiso.Get() != 99)
         {

--- a/src/main/cpp/vision/DragonQuest.cpp
+++ b/src/main/cpp/vision/DragonQuest.cpp
@@ -56,9 +56,9 @@ frc::Pose2d DragonQuest::GetEstimatedPose()
 
     units::length::meter_t x{posarray[2]};
     units::length::meter_t y{-posarray[0]};
-    units::length::meter_t z{posarray[1]};
-    units::angle::degree_t roll{rotationarray[0]};
-    units::angle::degree_t pitch{rotationarray[2]};
+    // units::length::meter_t z{posarray[1]};
+    // units::angle::degree_t roll{rotationarray[0]};
+    // units::angle::degree_t pitch{rotationarray[2]};
     units::angle::degree_t yaw{-rotationarray[1]};
 
     frc::Pose2d questPose{x, y, yaw};
@@ -101,6 +101,10 @@ void DragonQuest::DataLog(uint64_t timestamp)
     auto field = DragonField::GetInstance();
     field->AddPose("Quest", GetEstimatedPose());
     field->AddPose("Quest Initial Pose", m_initialQuestPose);
+
+    Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, "Quest", "Initial X Pose", m_initialQuestPose.X().value());
+    Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, "Quest", "Initial Y Pose", m_initialQuestPose.Y().value());
+    Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, "Quest", "Initial Yaw Pose", m_initialQuestPose.Rotation().Degrees().value());
 }
 
 void DragonQuest::RefreshNT()

--- a/src/main/cpp/vision/DragonQuest.h
+++ b/src/main/cpp/vision/DragonQuest.h
@@ -78,7 +78,10 @@ private:
     bool m_hasreset = false;
     bool m_isConnected = false;
 
+    frc::Transform2d m_robotToQuestTransform; // <I> Transform from robot center to Quest (used to calculate the quest pose from the robot pose)
     frc::Transform2d m_questTransform;
+
+    frc::Pose2d m_initialQuestPose; // <I> Previous pose used for logging purposes
 
     const double m_stdxy = 0.5;
     const double m_stddeg = 6.0;

--- a/src/main/cpp/vision/definitions/CameraConfigMgr.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfigMgr.cpp
@@ -65,7 +65,7 @@ void CameraConfigMgr::InitCameras(RobotIdentifier id)
 
     case RobotIdentifier::SIM_BOT_0:
         Logger::GetLogger()->LogData(LOGGER_LEVEL::ERROR_ONCE, string("Camera Init"), string("Success"), static_cast<int>(id));
-        m_config = new CameraConfig_9999();
+        m_config = new CameraConfig_302();
         break;
 
     default:

--- a/src/main/cpp/vision/definitions/CameraConfig_302.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfig_302.cpp
@@ -57,11 +57,11 @@ void CameraConfig_302::BuildCameraConfig()
     // ); // additional parameter
     // DragonVision::GetDragonVision()->AddLimelight(back, DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
 
-    // new DragonQuest(units::length::meter_t(-.319),  // <I> x offset of Quest from robot center (forward relative to robot)
-    //                 units::length::meter_t(0.0384), // <I> y offset of Quest from robot center (left relative to robot)
-    //                 units::length::meter_t(0.238),  // <I> z offset of Quest from robot center (up relative to robot)
-    //                 units::angle::degree_t(0),      // <I> - Pitch of Quest
-    //                 units::angle::degree_t(180),    // <I> - Yaw of Quest
-    //                 units::angle::degree_t(0)       // <I> - Roll of Quest
-    // );
+    new DragonQuest(units::length::meter_t(-0.319), // <I> x offset of Quest from robot center (forward relative to robot)
+                    units::length::meter_t(0.0384), // <I> y offset of Quest from robot center (left relative to robot)
+                    units::length::meter_t(0.238),  // <I> z offset of Quest from robot center (up relative to robot)
+                    units::angle::degree_t(0),      // <I> - Pitch of Quest
+                    units::angle::degree_t(180),    // <I> - Yaw of Quest
+                    units::angle::degree_t(0)       // <I> - Roll of Quest
+    );
 }


### PR DESCRIPTION
Verified Logic in Sim, I believe this will work when we actually have the quest. I did it by assuming that the quest was giving back perfect data (Chassis Pose - mounting offset) and then did the transform logic and on the field it should the RobotPose based on Odometery and the Robot pose calculated from the quest pose to be directly on top of each other